### PR TITLE
Fix worksheet indexing for first sheet

### DIFF
--- a/ExcelParser.cs
+++ b/ExcelParser.cs
@@ -167,7 +167,7 @@ namespace ExcelToStore
                             return new List<OrderRow>();
                         }
 
-                        worksheet = package.Workbook.Worksheets[0];
+                        worksheet = package.Workbook.Worksheets[1];
                         Logger.Debug("使用第一个工作表: {0}", worksheet.Name);
                     }
                     else


### PR DESCRIPTION
## Summary
- use 1-based worksheet index to avoid IndexOutOfRangeException when selecting first sheet

## Testing
- `dotnet build ExcelToStore.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*
- `msbuild ExcelToStore.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c8140ffc832aa0a0f040b4150297